### PR TITLE
feat: clean stale submodules before update

### DIFF
--- a/src/Utils.js
+++ b/src/Utils.js
@@ -177,17 +177,16 @@ function error(message) {
     process.stderr.write(text);
 }
 
-function exec(cmd, dir, quiet) {
-    if (!dir) {
-        dir = process.cwd();
-    } else {
-        dir = path.resolve(dir);
-    }
-    let options = {
+function spawnOptions(dir) {
+    return {
         shell: os.platform() === "win32" ? "cmd.exe" : true,
-        cwd: dir,
+        cwd: dir ? path.resolve(dir) : process.cwd(),
         env: process.env
-    }
+    };
+}
+
+function exec(cmd, dir, quiet) {
+    let options = spawnOptions(dir);
 
     if (!quiet) {
         options.stdio = "inherit";
@@ -204,22 +203,23 @@ function exec(cmd, dir, quiet) {
 }
 
 function execSafe(cmd, dir) {
-    if (!dir) {
-        dir = process.cwd();
-    } else {
-        dir = path.resolve(dir);
-    }
-    let options = {
-        shell: os.platform() === "win32" ? "cmd.exe" : true,
-        cwd: dir,
-        env: process.env
-    }
-
     try {
-        let result = childProcess.spawnSync(cmd, options);
+        let result = childProcess.spawnSync(cmd, spawnOptions(dir));
         return result.stdout.toString();
     } catch (e) {
         return "";
+    }
+}
+
+function execStatus(cmd, dir) {
+    try {
+        let result = childProcess.spawnSync(cmd, spawnOptions(dir));
+        if (result.status === null) {
+            return 1;
+        }
+        return result.status;
+    } catch (e) {
+        return 1;
     }
 }
 
@@ -259,6 +259,7 @@ exports.readFile = readFile;
 exports.writeFile = writeFile;
 exports.exec = exec;
 exports.execSafe = execSafe;
+exports.execStatus = execStatus;
 exports.log = log;
 exports.error = error;
 exports.compareVersion = compareVersion;

--- a/src/tasks/SubRepoTask.js
+++ b/src/tasks/SubRepoTask.js
@@ -43,6 +43,7 @@ SubRepoTask.prototype.run = function (callback) {
     }
     let modulesConfig = path.resolve(repoPath, ".gitmodules");
     if (fs.existsSync(modulesConfig)) {
+        cleanStaleSubmodules(repoPath, modulesConfig);
         Utils.exec("git submodule update --init --recursive --depth=1", repoPath, false);
     }
     let lfsConfig = path.resolve(repoPath, ".gitattributes");
@@ -66,5 +67,44 @@ SubRepoTask.prototype.run = function (callback) {
     }
     callback && callback();
 };
+
+function cleanStaleSubmodules(repoPath, modulesConfig) {
+    let content;
+    try {
+        content = fs.readFileSync(modulesConfig, "utf-8");
+    } catch (e) {
+        return;
+    }
+    let pathRegex = /^\s*path\s*=\s*(.+)/gm;
+    let match;
+    while ((match = pathRegex.exec(content)) !== null) {
+        let subPath = match[1].trim();
+        let subDir = path.resolve(repoPath, subPath);
+        if (!fs.existsSync(subDir)) {
+            continue;
+        }
+        let subGit = path.join(subDir, ".git");
+        let hasValidGit = false;
+        if (fs.existsSync(subGit)) {
+            try {
+                let stat = fs.lstatSync(subGit);
+                if (stat.isDirectory()) {
+                    hasValidGit = true;
+                } else if (stat.isFile()) {
+                    let link = fs.readFileSync(subGit, "utf-8").trim();
+                    let target = link.replace(/^gitdir:\s*/, "");
+                    let absTarget = path.resolve(subDir, target);
+                    hasValidGit = fs.existsSync(absTarget);
+                }
+            } catch (e) {
+            }
+        }
+        if (!hasValidGit) {
+            Utils.log("【depsync】cleaning stale submodule: " + subPath);
+            Utils.deletePath(subDir);
+            Utils.createDirectory(subDir);
+        }
+    }
+}
 
 module.exports = SubRepoTask;

--- a/src/tasks/SubRepoTask.js
+++ b/src/tasks/SubRepoTask.js
@@ -43,8 +43,7 @@ SubRepoTask.prototype.run = function (callback) {
     }
     let modulesConfig = path.resolve(repoPath, ".gitmodules");
     if (fs.existsSync(modulesConfig)) {
-        cleanStaleSubmodules(repoPath, modulesConfig);
-        Utils.exec("git submodule update --init --recursive --depth=1", repoPath, false);
+        updateSubmodules(repoPath, modulesConfig);
     }
     let lfsConfig = path.resolve(repoPath, ".gitattributes");
     if (fs.existsSync(lfsConfig)) {
@@ -68,43 +67,42 @@ SubRepoTask.prototype.run = function (callback) {
     callback && callback();
 };
 
-function cleanStaleSubmodules(repoPath, modulesConfig) {
-    let content;
-    try {
-        content = fs.readFileSync(modulesConfig, "utf-8");
-    } catch (e) {
+function updateSubmodules(repoPath, modulesConfig) {
+    let cmd = "git submodule update --init --recursive --depth=1";
+    if (Utils.execStatus(cmd, repoPath) === 0) {
         return;
     }
-    let pathRegex = /^\s*path\s*=\s*(.+)/gm;
-    let match;
-    while ((match = pathRegex.exec(content)) !== null) {
-        let subPath = match[1].trim();
+    Utils.log("【depsync】submodule update failed, cleaning stale submodules...");
+    let subPaths = parseSubmodulePaths(modulesConfig);
+    for (let subPath of subPaths) {
+        let quoted = process.platform === "win32" ? '"' + subPath.replace(/"/g, '\\"') + '"' : "'" + subPath.replace(/'/g, "'\\''") + "'";
+        Utils.execStatus("git submodule deinit -f -- " + quoted, repoPath);
+        let moduleCacheDir = path.resolve(repoPath, ".git", "modules", subPath);
+        if (fs.existsSync(moduleCacheDir)) {
+            Utils.deletePath(moduleCacheDir);
+        }
         let subDir = path.resolve(repoPath, subPath);
-        if (!fs.existsSync(subDir)) {
-            continue;
-        }
-        let subGit = path.join(subDir, ".git");
-        let hasValidGit = false;
-        if (fs.existsSync(subGit)) {
-            try {
-                let stat = fs.lstatSync(subGit);
-                if (stat.isDirectory()) {
-                    hasValidGit = true;
-                } else if (stat.isFile()) {
-                    let link = fs.readFileSync(subGit, "utf-8").trim();
-                    let target = link.replace(/^gitdir:\s*/, "");
-                    let absTarget = path.resolve(subDir, target);
-                    hasValidGit = fs.existsSync(absTarget);
-                }
-            } catch (e) {
-            }
-        }
-        if (!hasValidGit) {
-            Utils.log("【depsync】cleaning stale submodule: " + subPath);
+        if (fs.existsSync(subDir)) {
             Utils.deletePath(subDir);
-            Utils.createDirectory(subDir);
         }
     }
+    Utils.exec(cmd, repoPath, false);
+}
+
+function parseSubmodulePaths(modulesConfig) {
+    let paths = [];
+    try {
+        let content = fs.readFileSync(modulesConfig, "utf-8");
+        let pathRegex = /^\s*path\s*=\s*(.+)/gm;
+        let match;
+        while ((match = pathRegex.exec(content)) !== null) {
+            paths.push(match[1].trim());
+        }
+    } catch (e) {
+        Utils.error("【depsync】failed to parse .gitmodules: " + e.message);
+    }
+    return paths;
 }
 
 module.exports = SubRepoTask;
+


### PR DESCRIPTION
Add cleanStaleSubmodules() to detect and remove submodule directories with invalid .git references before running git submodule update, preventing update failures caused by corrupted submodule state.